### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: testing
+name: build
 on:
   pull_request:
     branches:
@@ -7,6 +7,7 @@ on:
     types: [opened, reopened, edited, synchronize]
     paths:
       - '**.js'
+      - 'test/**'
 jobs:
   coverage:
     runs-on: ubuntu-latest
@@ -15,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: npm i
     - name: Generate coverage report
-      run: npm test
+      run: npm run coverage
     - name: Upload report to Code Climate
       uses: kaskadi/action-cc-reporter@master
       env:

--- a/.github/workflows/buildChrome.yml
+++ b/.github/workflows/buildChrome.yml
@@ -3,11 +3,11 @@ on:
   pull_request:
     branches:
       - 'master'
-      - 'dev'
+      - 'release/**'
     types: [opened, reopened, edited, synchronize]
     paths:
       - '**.js'
-      - 'example/index.html'
+      - 'test/**'
 jobs:
   buildChrome:
     runs-on: ubuntu-latest

--- a/.github/workflows/buildFF.yml
+++ b/.github/workflows/buildFF.yml
@@ -3,11 +3,11 @@ on:
   pull_request:
     branches:
       - 'master'
-      - 'dev'
+      - 'release/**'
     types: [opened, reopened, edited, synchronize]
     paths:
       - '**.js'
-      - 'example/index.html'
+      - 'test/**'
 jobs:
   buildFF:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,30 @@
+name: generate-docs
+on:
+  push:
+    branches:
+      - 'master'
+      - 'release/**'
+    paths:
+      - '**.js'
+      - 'package.json'
+      - 'docs/**'
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: npm i
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: element
+        template: docs/template.md

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,22 +7,19 @@ on:
     paths:
       - '**.js'
       - 'example/index.html'
-      - '**.json'
+      - 'package.json'
 env:
   AWS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
   AWS_KEY_SECRET: ${{ secrets.AWS_KEY_SECRET }}
   BUCKET: ${{ secrets.S3_PUBLIC_BUCKET }}
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Install dependencies
       run: npm i
-    - uses: paambaati/codeclimate-action@v2.4.0
-      env:
-        CC_TEST_REPORTER_ID: ${{ secrets.REPORTER_ID }}
-      with:
-        coverageCommand: npm test
+    - name: Test
+      run: npm test
     - name: Upload files to S3 bucket
       uses: kaskadi/action-s3cp@master

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,33 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/kaskadi-date-icon)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/kaskadi-date-icon?color=blue)
+
+[![](https://img.shields.io/badge/live-example-orange)](https://cdn.klimapartner.net/modules/%40kaskadi/kaskadi-date-icon/example/index.html)
+
+**GitHub Actions workflows status**
+
+[![Build status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-date-icon/build?label=build&logo=mocha)](https://github.com/kaskadi/kaskadi-date-icon/actions?query=workflow%3Abuild)
+[![BuildFF status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-date-icon/build-on-firefox?label=firefox&logo=Mozilla%20Firefox&logoColor=white)](https://github.com/kaskadi/kaskadi-date-icon/actions?query=workflow%3Abuild-on-firefox)
+[![BuildChrome status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-date-icon/build-on-chrome?label=chrome&logo=Google%20Chrome&logoColor=white)](https://github.com/kaskadi/kaskadi-date-icon/actions?query=workflow%3Abuild-on-chrome)
+[![Publish status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-date-icon/publish?label=publish&logo=Amazon%20AWS)](https://github.com/kaskadi/kaskadi-date-icon/actions?query=workflow%3Apublish)
+[![Docs generation status](https://img.shields.io/github/workflow/status/kaskadi/kaskadi-date-icon/generate-docs?label=docs&logo=read-the-docs)](https://github.com/kaskadi/kaskadi-date-icon/actions?query=workflow%3Agenerate-docs)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/kaskadi-date-icon?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-date-icon)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/kaskadi-date-icon?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-date-icon)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/kaskadi-date-icon?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/kaskadi-date-icon)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/kaskadi-date-icon?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/kaskadi-date-icon/?mode=list&logo=LGTM)
+
+<!-- You can add badges inside of this section if you'd like -->
+
+****
+
+<!-- automatically generated documentation will be placed in here -->
+{{>main}}
+<!-- automatically generated documentation will be placed in here -->
+
+<!-- You can customize this template as you'd like! -->

--- a/kaskadi-date-icon.js
+++ b/kaskadi-date-icon.js
@@ -1,6 +1,6 @@
 /* global customElements */
 import { KaskadiElement, css, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
-import './locals.js'
+
 class KaskadiDateIcon extends KaskadiElement {
   constructor () {
     super()

--- a/kaskadi-date-icon.js
+++ b/kaskadi-date-icon.js
@@ -1,7 +1,7 @@
 /* global customElements */
-import { html, css, LitElement } from 'https://cdn.klimapartner.net/modules/lit-element/lit-element.js'
+import { KaskadiElement, css, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
 import './locals.js'
-class KaskadiDateIcon extends LitElement {
+class KaskadiDateIcon extends KaskadiElement {
   constructor () {
     super()
     this.size = 64

--- a/kaskadi-date-icon.js
+++ b/kaskadi-date-icon.js
@@ -1,6 +1,22 @@
 /* global customElements */
 import { KaskadiElement, css, html } from 'https://cdn.klimapartner.net/modules/@kaskadi/kaskadi-element/kaskadi-element.js'
 
+/**
+ * An element to display a date as a calendar icon.
+ *
+ * This also supports styling via custom CSS properties.
+ *
+ * @module kaskadi-date-icon
+ *
+ * @param {string} date - date that should be displayed by the element. Supports the same date format as the one you would use when instanciating a new date via the [Date API](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/Date)
+ * @param {string} lang - element's language
+ * @param {string} style - regular inline style. See the live example for illustration. Supports the following custom CSS properties: `--icon-size`, `--background-color`, `--outline-color`, `--head-color`, `--day-color`, `--month-color` and `--name-color`
+ *
+ * @example
+ *
+ * <kaskadi-date-icon date="1975-04-07" lang="en" style="--icon-size: 16px;"></kaskadi-date-icon>
+ */
+
 class KaskadiDateIcon extends KaskadiElement {
   constructor () {
     super()

--- a/kaskadi-date-icon.js
+++ b/kaskadi-date-icon.js
@@ -9,11 +9,13 @@ class KaskadiDateIcon extends KaskadiElement {
     this.lang = 'de'
     this.weekDayNames = {
       de: ['Sonntag', 'Montag', 'Dienstag', 'Mittwoch', 'Donnerstag', 'Freitag', 'Samstag'],
-      en: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
+      en: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+      fr: ['Dimanche', 'Lundi', 'Mardi', 'Mercredi', 'Jeudi', 'Vendredi', 'Samedi']
     }
     this.monthNames = {
-      de: ['Jan', 'Feb', 'Mär', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
-      en: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec']
+      de: ['Jan', 'Feb', 'M\u00e4r', 'Apr', 'Mai', 'Jun', 'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dez'],
+      en: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+      fr: ['Jan', 'F\u00e9v', 'Mar', 'Avr', 'Mai', 'Juin', 'Juil', 'Ao\u00fbt', 'Sep', 'Oct', 'Nov', 'Dec']
     }
   }
 

--- a/locals.js
+++ b/locals.js
@@ -1,9 +1,0 @@
-export const locals = {
-  monday: {
-    en: 'Monday',
-    de: 'Montag',
-    fr: 'Lundi'
-  }
-}
-
-export default locals

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -18,4 +18,10 @@ describe('kaskadi-date-icon', () => {
     var cs = getComputedStyle(elem.shadowRoot.querySelector('#outline'))
     cs.stroke.should.equal('rgb(255, 0, 0)')
   })
+  it('testing no date', async () => {
+    var elem = document.createElement('kaskadi-date-icon')
+    document.body.appendChild(elem)
+    await elem.updateComplete
+    elem.should.have.property('_date')
+  })
 })


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using the GitHub action `action-generate-docs` inside of a new `generate-docs` workflow. This uses a template located under `docs/template.md`. Also aligned workflows syntax with new template.

**New features**
- _`generate-docs` workflow:_ workflow running on push (same triggers as `publish`) that generates the element documentation automatically using `action-generate-docs`
- _documentation template:_ added template for documentation under `docs/template.md`

**Updated features**
- _`template-kaskadi-element.js`:_ added JSDoc comments for documentation. Using `kaskadi-element` as parent class (instead of `LitElement`). Added french localization for months and days.
- _tests:_ expanded coverage to all branches
- _`locals.js`:_ removed, not used
- _`build`/`publish` workflows:_ fixed triggers as well as configuration of the workflow (f.e. running actual code coverage)